### PR TITLE
Ability to define required scopes by the middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Required scopes allows the exchange middleware to throw an error if the user doe
 The requiredScopes are specified within the options (`opts`) object.
 
 ```js
+// ...
+
 server.exchange(
     oauth2orizeFacebook(
         {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ server.exchange(oauth2orizeFacebook(function (client, profile, scope, cb) {
 Required scopes allows the exchange middleware to throw an error if the user does not allow a permission required for the application to work.
 The requiredScopes are specified within the options (`opts`) object.
 
-```
+```js
 server.exchange(
     oauth2orizeFacebook(
         {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ server.exchange(oauth2orizeFacebook(function (client, profile, scope, cb) {
 }));
 ```
 
+
+## Options
+
+**requiredScopes**
+
+Required scopes allows the exchange middleware to throw an error if the user does not allow a permission required for the application to work.
+The requiredScopes are specified within the options (`opts`) object.
+
+```
+server.exchange(
+    oauth2orizeFacebook(
+        {
+            requiredScopes: ['scope1', 'scope2']
+        },
+        function (client, profile, scope, cb) {
+            // ...
+        }
+    )
+);
+```
 ## License
 
 MIT licensed.

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ module.exports = function (opts, issue) {
 
   var userProperty = opts.userProperty || 'user';
   var separators = opts.scopeSeparator || ' ';
+  var requiredScopes = opts.requiredScopes || [];
 
   if (!Array.isArray(separators)) {
     separators = [ separators ];
@@ -43,10 +44,10 @@ module.exports = function (opts, issue) {
         'Missing Facebook access token!', 'invalid_request'));
     }
 
-    getFacebookProfile(token, function (err, profile) {
+    getFacebookProfile(token, requiredScopes, function (err, profile) {
       if (err) {
         return next(new AuthorizationError(
-          'Could not get Facebook profile using provided access token.',
+          err.message || 'Could not get Facebook profile using provided access token.',
           'invalid_request'
         ));
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,14 @@ module.exports = function (opts, issue) {
   var separators = opts.scopeSeparator || ' ';
   var requiredScopes = opts.requiredScopes || [];
 
+  if (!Array.isArray(requiredScopes)) {
+        if (typeof(requiredScopes) === 'string') {
+            requiredScopes = [ requiredScopes ];
+        } else {
+            requiredScopes = [];
+        }
+    }
+
   if (!Array.isArray(separators)) {
     separators = [ separators ];
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@
 
 var request = require('request');
 
-exports.getFacebookProfile = function (accessToken, cb) {
+exports.getFacebookProfile = function (accessToken, requiredScopes, cb) {
   request({
     url: 'https://graph.facebook.com/me?access_token=' + accessToken,
     json: true
@@ -17,6 +17,51 @@ exports.getFacebookProfile = function (accessToken, cb) {
       return cb(new Error(msg));
     }
 
-    cb(null, body);
+    if (!requiredScopes) {
+      return cb(null, body);
+    }
+
+    getFacebookPermissions(accessToken, function(err, scopes) {
+      var grantedScopes = [];
+
+      for (var index in scopes) {
+        if (scopes.hasOwnProperty(index)) {
+          var scope = scopes[index];
+
+          if (scope.status === 'granted') {
+            grantedScopes.push(scope.permission);
+          }
+        }
+      }
+
+      for (var index in requiredScopes) {
+        if (requiredScopes.hasOwnProperty(index)) {
+          var rScope = requiredScopes[index];
+          if (grantedScopes.indexOf(rScope) === -1) {
+            var msg = 'Facebook profile authorization has insufficient scopes';
+            return cb(new Error(msg));
+          }
+        }
+      }
+      cb(null, body);
+    });
+  };
+
+getFacebookPermissions = function(accessToken, cb) {
+  request({
+    url: 'https://graph.facebook.com/me/permissions?access_token=' + accessToken,
+    json: true
+  },
+  function (err, res, body) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (body && body.error) {
+      var msg = body.error.message || 'Could not get Facebook profile permissions.';
+      return cb(new Error(msg));
+    }
+
+    cb(null, body.data);
   });
-};
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,7 @@ exports.getFacebookProfile = function (accessToken, requiredScopes, cb) {
       return cb(new Error(msg));
     }
 
-    if (!requiredScopes) {
+     if (requiredScopes.length === 0) {
       return cb(null, body);
     }
 


### PR DESCRIPTION
This PR brings the ability to add an array with required scopes (permissions) which are checked against the authorized scopes from the user. Facebook allows users the choice to dis-allow scopes our application really needs. Say, for example, we really need the email scope for our application to work, but the user doesn't want to authorize us being able to view their email address. This allows us to throw an error back to the client saying we do really need that email scope.

The client can then keep asking for the right scopes until the users either choses to authorize it, or decides not to use facebook for our application.
